### PR TITLE
Fix for devtools bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,8 +9,8 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Imports: shiny,
-    shinyjs,
-    dplyr,
-    digest,
-    rlang
+ shinyjs,
+ dplyr,
+ digest,
+ rlang
 RoxygenNote: 6.1.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,8 @@ Maintainer: Paul Campbell <pacampbell91@gmail.com>
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-Imports: shiny,
+Imports: 
+ shiny,
  shinyjs,
  dplyr,
  digest,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,10 +8,5 @@ Maintainer: Paul Campbell <pacampbell91@gmail.com>
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-Imports: 
- shiny,
- shinyjs,
- dplyr,
- digest,
- rlang
+Imports: shiny, shinyjs, dplyr, digest, rlang
 RoxygenNote: 6.1.0


### PR DESCRIPTION
There seems to be an issue with indenting a list of imports in the DESCRIPTION file. It breaks the install from the Github repository with the following error message: 

> Error in read.dcf(path) : 
>   Found continuation line starting '    shinyjs, ...' at begin of record

Removing all newlines resolves this issue. 