### PR TITLE
enable cookie-based authentification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .Ruserdata
 *.Rproj
 inst/shiny-examples/shinyauthr_example/rsconnect/
+_install.R

--- a/R/internal.R
+++ b/R/internal.R
@@ -1,0 +1,6 @@
+# function to create a random sting with standard length 64
+# modified after: https://gist.github.com/calligross/e779281b500eb93ee9e42e4d72448189
+randomString <- function(n = 64) {
+    paste(sample(x = c(letters, LETTERS, 0:9), size = n, replace = TRUE),
+          collapse = "")
+}

--- a/R/login.R
+++ b/R/login.R
@@ -133,7 +133,8 @@ login <- function(input, output, session, data, user_col, pwd_col, cookie_col,
       credentials$user_auth <- TRUE
       credentials$info <- dplyr::mutate_at(
           dplyr::filter(data, !! users == input$user_name),
-          as.character(quo_get_expr(cookies)), function(x){return(sessionid)})
+          as.character(rlang::quo_get_expr(cookies)), 
+          function(x){return(sessionid)})
     } else { # if not valid temporarily show error message to user
       shinyjs::toggle(id = "error", anim = TRUE, time = 1, animType = "fade")
       shinyjs::delay(5000, shinyjs::toggle(id = "error", anim = TRUE, time = 1, animType = "fade"))


### PR DESCRIPTION
Finding your [issue 10](https://github.com/PaulC91/shinyauthr/issues/10) and calligross's [Shiny Cookie Based Authentication Example](https://gist.github.com/calligross/e779281b500eb93ee9e42e4d72448189) I simply combined the code and created this PR.