### PR TITLE
Update README.md on user base creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ user_base <- data.frame(
   password = c("pass1", "pass2"), 
   permissions = c("admin", "standard"),
   name = c("User One", "User Two"),
-  stringsAsFactors = FALSE
+  stringsAsFactors = FALSE,
+  row.names = NULL
 )
 
 ui <- fluidPage(
@@ -104,7 +105,8 @@ user_base <- data.frame(
   password = sapply(c("pass1", "pass2"), sodium::password_store), 
   permissions = c("admin", "standard"),
   name = c("User One", "User Two"),
-  stringsAsFactors = FALSE
+  stringsAsFactors = FALSE,
+  row.names = NULL
 )
 
 saveRDS(user_base, "user_base.rds")


### PR DESCRIPTION
Currently, if we create the user base without `row.names = NULL`, we are storing the actual (non-hashed) passwords as row names in the data frame, so adding `row.names = NULL` will do the trick.