### PR TITLE
Adding tests

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,3 +3,4 @@
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$
+^\.travis\.yml$

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+# R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
+
+language: R
+cache: packages

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,9 @@ Imports:
     shinyjs,
     dplyr,
     rlang,
-    sodium
+    sodium,
+    shinytest,
+    testthat
 RoxygenNote: 6.1.1
 URL: https://github.com/paulc91/shinyauthr
 BugReports: https://github.com/paulc91/shinyauthr/issues

--- a/inst/shiny-examples/shinyauthr_example/app.R
+++ b/inst/shiny-examples/shinyauthr_example/app.R
@@ -108,6 +108,12 @@ server <- function(input, output, session) {
     )
   })
   
+  # Export reactive values for testing
+  exportTestValues(
+    auth_status = credentials()$user_auth,
+    auth_info   = credentials()$info
+  )
+  
 }
 
 shiny::shinyApp(ui, server)

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(shinyauthr)
+
+testthat::test_check("shinyauthr")

--- a/tests/testthat/helper-shinyauthr.R
+++ b/tests/testthat/helper-shinyauthr.R
@@ -1,0 +1,24 @@
+library(shinytest)
+library(shiny)
+
+options(shiny.testmode = TRUE)
+
+# Init shiny driver for testing
+get_app <- function() {
+  
+  app <- ShinyDriver$new(system.file("shiny-examples", "shinyauthr_example",
+                                     package = "shinyauthr"))
+  
+  return(app)
+  
+}
+
+
+# Steps to authenthicate user
+app_login <- function(app, role = "admin") {
+  app$setInputs(`login-password` = if(role == 'admin') "pass1" else "pass2")
+  app$setInputs(`login-user_name` = if(role == 'admin') "user1" else "pass2")
+  app$setInputs(`login-button` = "click")
+  
+  Sys.sleep(1)  # wait for UI elements to load/update
+}

--- a/tests/testthat/test-shinyauthr.R
+++ b/tests/testthat/test-shinyauthr.R
@@ -24,7 +24,6 @@ test_that("user_auth and info get updated after successful login", {
   app_login(app, role = "admin")
   
   values <- app$getAllValues()
-  print(values) # 
   testthat::expect_true(values$export$auth_status) 
   testthat::expect_s3_class(values$export$auth_info, "data.frame")
   

--- a/tests/testthat/test-shinyauthr.R
+++ b/tests/testthat/test-shinyauthr.R
@@ -1,0 +1,98 @@
+library(testthat)
+library(shinytest)
+library(dplyr)
+
+app <- get_app()
+
+
+## Login ---------------------
+test_that("login form renders and sidebar is collapsed", {
+  
+  user_input <- app$findElement(xpath = "//input[@id='login-user_name']")
+  pass_input <- app$findElement(xpath = "//input[@id='login-password']")
+  sidebar <- app$getAllValues()$input$sidebarCollapsed
+  
+  testthat::expect_equal(user_input$getText(), "")
+  testthat::expect_equal(pass_input$getText(), "")
+  testthat::expect_true(sidebar)
+  
+})
+
+
+test_that("user_auth and info get updated after successful login", {
+  
+  app_login(app, role = "admin")
+  
+  values <- app$getAllValues()
+  print(values) # 
+  testthat::expect_true(values$export$auth_status) 
+  testthat::expect_s3_class(values$export$auth_info, "data.frame")
+  
+})
+
+
+test_that("logout button and sidebar display after successful login", {
+  
+  app_login(app, role = "admin")
+  
+  logout_button <- app$findElement(xpath = "//button[@id='logout-button']")
+  sidebar <- app$getAllValues()$input$sidebarCollapsed
+  
+  testthat::expect_false(sidebar)
+  testthat::expect_equal(logout_button$getText(), "Log out")  # display logout button
+  
+})
+
+# test_that("starwars dataset is shown to admins", {
+#   
+#   app_login(app, role = "admin")
+#   values <- app$getAllValues()
+#   
+#   print(values$export$user_data)
+#   
+#   testthat::expect_identical(data, dplyr::starwars[, 1:10])
+#   
+# })
+
+# test_that("storms is shown to standard accounts", {
+#   
+#   app_login(app, role = "standard")
+#   values <- app$getAllValues()
+#   
+#   testthat::expect_identical(data, dplyr::storms[, 1:11])
+#   
+# })
+
+
+
+## Logout ---------------------
+test_that("user_auth and info get updated after successful logout", {
+
+  # Authenticate and logout
+  app_login(app, role = "admin")
+  app$setInputs(`logout-button` = "click")
+  Sys.sleep(1)
+  
+  values <- app$getAllValues()
+  
+  testthat::expect_false(values$export$auth_status)  # user_auth updates
+  testthat::expect_null(values$export$auth_info)  # user_info updates
+  
+})
+
+
+test_that("credentials are updated and logout button hides after successful logout", {
+  
+  # Authenticate and logout
+  app_login(app, role = "admin")
+  app$setInputs(`logout-button` = "click")
+  Sys.sleep(1)
+  
+  sidebar <- app$getAllValues()$input$sidebarCollapsed
+  logout_button <- app$findElement(xpath = "//button[@id='logout-button']")
+  logout_display <- strsplit(logout_button$getAttribute("style"), ";")[[1]][2]
+  
+  testthat::expect_true(sidebar)
+  testthat::expect_match(logout_display, "display: none")  # hide logout button
+  
+})


### PR DESCRIPTION
After experimenting with couple different approaches, I believe testing `shinyauthr` functionalities against the Shiny example app in `inst/` would be the most practical way as it allows to test the user-facing interface (leaving room to change the underlying logic, e.g hashing, etc.).

Tests have been structured as:  
**Login**:
  * Login form displays properly (empty `user_name` and `password` fields with collapsed sidebar).
  * If a user logs in successfully `user_auth` is set to _TRUE_  and `info` gets update with user infos.
  * When a user logs in successfully `sidebarCollapsed` is set to _FALSE_ and logout button displays.

**Logout**:
  * Logging out successfully sets `user_auth` to _FALSE_ and `info` to _NULL_
  * Logging out hides logout button and sets `sidebarCollapsed` to  _TRUE_

Tests run well under a minute (~26secs.), hence it shouldn't be required to skip tests when submitting.

Would be really interesting to understand if I overlooked any better approach to do this.

### Help needed
Exporting values is needed in order to inspect them during testing. This is done by adding a call to `exportTestValues()` in `app.R`.
```r
  # Export reactive values for testing
  exportTestValues(
    auth_status = credentials()$user_auth,
    auth_info   = credentials()$info,
    user_data    = user_data()  # this throws an error
  )
```
On the other hand, exporting `user_data()` reactive data frame breaks the call, trowing the following error (even when in testmode): 
```
Unable to fetch all values from server. Is target app running with options(shiny.testmode=TRUE?)
```
This is blocking me from testing the right data is being show to user respecting their permission level. Hence tests have been commented out `test-shinyauthr.R`.

I am probably missing something obvious here but the same call works like a charm on a mock Shiny app.
