### PR TITLE
Bug fix for apps not using cookie authentication feature

### DIFF
--- a/R/internal.R
+++ b/R/internal.R
@@ -29,8 +29,10 @@ NULL
 
 #' @rdname cookie_placeholders
 #' @keywords internal
-default_cookie_getter <- function(){
-	data.frame(user = character(0), session = character(0))
+default_cookie_getter <- function(user_string, session_string){
+	df <- data.frame(user = character(0), session = character(0))
+	names(df) <- c(user_string, session_string)
+	function(){df}
 }
 
 

--- a/R/login.R
+++ b/R/login.R
@@ -122,7 +122,7 @@ login <- function(input, output, session, data, user_col, pwd_col, sodium_hashed
   pwds <- dplyr::enquo(pwd_col)
 
   if(missing(cookie_getter) | missing(cookie_setter) | missing(sessionid_col)){
-    cookie_getter <- default_cookie_getter
+    cookie_getter <- default_cookie_getter(dplyr::as_label(users), "session_id")
     cookie_setter <- default_cookie_setter
     sessionids <- "session_id"
   } else{

--- a/inst/shiny-examples/broken/app.R
+++ b/inst/shiny-examples/broken/app.R
@@ -1,0 +1,52 @@
+library(shiny)
+library(shinyauthr)
+library(shinyjs)
+
+# dataframe that holds usernames, passwords and other user data
+user_base <- data.frame(
+	username = c("user1", "user2"), # in original app, this was called user.  Changing to username breaks the app until we fix default_cookie_getter
+	password = c("pass1", "pass2"),
+	permissions = c("admin", "standard"),
+	name = c("User One", "User Two"),
+	stringsAsFactors = FALSE,
+	row.names = NULL
+)
+
+ui <- fluidPage(
+	# must turn shinyjs on
+	shinyjs::useShinyjs(),
+	# add logout button UI
+	div(class = "pull-right", logoutUI(id = "logout")),
+	# add login panel UI function
+	loginUI(id = "login"),
+	# setup table output to show user info after login
+	tableOutput("user_table")
+)
+
+server <- function(input, output, session) {
+
+	# call the logout module with reactive trigger to hide/show
+	logout_init <- callModule(shinyauthr::logout,
+							  id = "logout",
+							  active = reactive(credentials()$user_auth))
+
+	# call login module supplying data frame, user and password cols
+	# and reactive trigger
+	credentials <- callModule(shinyauthr::login,
+							  id = "login",
+							  data = user_base,
+							  user_col = username,
+							  pwd_col = password,
+							  log_out = reactive(logout_init()))
+
+	# pulls out the user information returned from login module
+	user_data <- reactive({credentials()$info})
+
+	output$user_table <- renderTable({
+		# use req to only render results when credentials()$user_auth is TRUE
+		req(credentials()$user_auth)
+		user_data()
+	})
+}
+
+shinyApp(ui = ui, server = server)

--- a/man/cookie_placeholders.Rd
+++ b/man/cookie_placeholders.Rd
@@ -6,7 +6,7 @@
 \alias{default_cookie_setter}
 \title{Place Holder Database Cookie Handlers}
 \usage{
-default_cookie_getter()
+default_cookie_getter(user_string, session_string)
 
 default_cookie_setter(user, session)
 }


### PR DESCRIPTION
This fixes a bug that I just found.  If an app does not use the cookie authentication, then shinyauthr uses a default cookie getter function.  Unfortunately this did not respect the app's choice of user_col and would crash unless the app happened to use user_col=user.  I added an example app in inst/shiny-examples/broken/app.R that crashes under the old version (which was just merged) but works correctly with the changes contained in this PR.

Sorry about this.