### PR TITLE
Fix usage of `shinyjs` closes #47

### DIFF
--- a/R/login.R
+++ b/R/login.R
@@ -26,6 +26,7 @@ loginUI <- function(id, title = "Please log in", user_title = "User Name", pass_
     shiny::div(id = ns("panel"), style = "width: 500px; max-width: 100%; margin: 0 auto; padding: 20px;",
       shiny::wellPanel(
 
+        shinyjs::useShinyjs(),
         jscookie_script(),
         shinyjs::extendShinyjs(text = js_cookie_to_r_code(ns("jscookie")), functions=c("getcookie","setcookie","rmcookie")),
         shinyjs::extendShinyjs(text = js_return_click(ns("password"), ns("button")), functions = c()),
@@ -52,8 +53,6 @@ loginUI <- function(id, title = "Please log in", user_title = "User Name", pass_
     )
   )
 }
-
-utils::globalVariables("js")
 
 #' login server module
 #'
@@ -106,7 +105,7 @@ login <- function(input, output, session, data, user_col, pwd_col, sodium_hashed
   shiny::observeEvent(log_out(), {
     credentials$user_auth <- FALSE
     credentials$info <- NULL
-    js$rmcookie()
+    shinyjs::js$rmcookie()
     shiny::updateTextInput(session, "password", value = "")
   })
 
@@ -136,8 +135,8 @@ login <- function(input, output, session, data, user_col, pwd_col, sodium_hashed
 
   # possibility 1: login through a present valid cookie
   # first, check for a cookie once javascript is ready
-  shiny::observeEvent(shiny::isTruthy(js$getcookie()),{
-    js$getcookie()
+  shiny::observeEvent(shiny::isTruthy(shinyjs::js$getcookie()),{
+    shinyjs::js$getcookie()
   })
   # second, once cookie is found try to use it
   shiny::observeEvent(input$jscookie, {
@@ -152,13 +151,13 @@ login <- function(input, output, session, data, user_col, pwd_col, sodium_hashed
     cookie_data <- dplyr::filter(cookie_getter(), !!sessionids == input$jscookie)
 
     if(nrow(cookie_data) != 1){
-      js$rmcookie()
+      shinyjs::js$rmcookie()
     } else {
       # if valid cookie, we reset it to update expiry date
       .userid <- dplyr::pull(cookie_data, !!users)
       .sessionid <- randomString()
 
-      js$setcookie(.sessionid)
+      shinyjs::js$setcookie(.sessionid)
 
       cookie_setter(.userid, .sessionid)
 
@@ -193,7 +192,7 @@ login <- function(input, output, session, data, user_col, pwd_col, sodium_hashed
     # if user name row and password name row are same, credentials are valid
     if (length(row_username) == 1 && password_match) {
       .sessionid <- randomString()
-      js$setcookie(.sessionid)
+      shinyjs::js$setcookie(.sessionid)
 
       cookie_setter(input$user_name, .sessionid)
 

--- a/README.md
+++ b/README.md
@@ -33,12 +33,10 @@ The package provides 2 module functions each with a UI and server element:
 - `logout()`
 - `logoutUI()`
 
-Below is a minimal reproducible example of how to use the authentication modules in a shiny app. Note that you must initiate the use of the shinyjs package with `shinyjs::useShinyjs()` in your UI code for this to work appropriately.
+Below is a minimal reproducible example of how to use the authentication modules in a shiny app. Note that this package invisibly calls `shinyjs::useShinyjs()` and there is no need for you to do so (although there is no harm if you do).
 
 ```r
 library(shiny)
-library(shinyauthr)
-library(shinyjs)
 
 # dataframe that holds usernames, passwords and other user data
 user_base <- data.frame(
@@ -51,12 +49,10 @@ user_base <- data.frame(
 )
 
 ui <- fluidPage(
-  # must turn shinyjs on
-  shinyjs::useShinyjs(),
   # add logout button UI 
-  div(class = "pull-right", logoutUI(id = "logout")),
+  div(class = "pull-right", shinyauthr::logoutUI(id = "logout")),
   # add login panel UI function
-  loginUI(id = "login"),
+  shinyauthr::loginUI(id = "login"),
   # setup table output to show user info after login
   tableOutput("user_table")
 )
@@ -103,8 +99,6 @@ Pass these functions to the login module via `callModule(shinyauthr::login, ...)
 
 ```r
 library(shiny)
-library(shinyauthr)
-library(shinyjs)
 library(dplyr)
 library(lubridate)
 library(DBI)
@@ -148,12 +142,10 @@ user_base <- data.frame(
 )
 
 ui <- fluidPage(
-	# must turn shinyjs on
-	shinyjs::useShinyjs(),
 	# add logout button UI
-	div(class = "pull-right", logoutUI(id = "logout")),
+	div(class = "pull-right", shinyauthr::logoutUI(id = "logout")),
 	# add login panel UI function
-	loginUI(id = "login", cookie_expiry = cookie_expiry),
+	shinyauthr::loginUI(id = "login", cookie_expiry = cookie_expiry),
 	# setup table output to show user info after login
 	tableOutput("user_table")
 )

--- a/inst/shiny-examples/broken/app.R
+++ b/inst/shiny-examples/broken/app.R
@@ -1,6 +1,4 @@
 library(shiny)
-library(shinyauthr)
-library(shinyjs)
 
 # dataframe that holds usernames, passwords and other user data
 user_base <- data.frame(
@@ -13,12 +11,10 @@ user_base <- data.frame(
 )
 
 ui <- fluidPage(
-	# must turn shinyjs on
-	shinyjs::useShinyjs(),
 	# add logout button UI
-	div(class = "pull-right", logoutUI(id = "logout")),
+	div(class = "pull-right", shinyauthr::logoutUI(id = "logout")),
 	# add login panel UI function
-	loginUI(id = "login"),
+	shinyauthr::loginUI(id = "login"),
 	# setup table output to show user info after login
 	tableOutput("user_table")
 )

--- a/inst/shiny-examples/shinyauthr_example/app.R
+++ b/inst/shiny-examples/shinyauthr_example/app.R
@@ -1,7 +1,6 @@
 library(shiny)
 library(shinydashboard)
 library(dplyr)
-library(shinyjs)
 library(glue)
 library(shinyauthr)
 library(RSQLite)
@@ -57,7 +56,6 @@ ui <- dashboardPage(
   ),
 
   dashboardBody(
-    shinyjs::useShinyjs(),
     tags$head(tags$style(".table{margin: 0 auto;}"),
               tags$script(src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/3.5.16/iframeResizer.contentWindow.min.js",
                           type="text/javascript")


### PR DESCRIPTION
This PR replaces the `js$...` calls with `shinyjs::js$...`.  This change means the app using `shinyauthr` does not need to call `library(shinyjs)`.

At the same time, `loginUI` now calls `shinyjs::useShinyjs()` and so there is no need for the main app to do so.  This should simplify things for app developers.