### PR TITLE
Explicit use of shinyauthr for running examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Code for example apps using various UI frameworks can be found in [inst/shiny-ex
 
 ``` r
 # login with user1 pass1 or user2 pass2
-runExample("basic")
-runExample("shinydashboard")
-runExample("navbarPage")
+shinyauthr::runExample("basic")
+shinyauthr::runExample("shinydashboard")
+shinyauthr::runExample("navbarPage")
 ```
 
 ## Usage


### PR DESCRIPTION
If you run `runExample("navbarPage")`, you may get:
```
Error in runExample("navbarPage") : 
  Example navbarPage does not exist. Valid examples are "01_hello", "02_text", "03_reactivity", "04_mpg", "05_sliders", "06_tabsets", "07_widgets", "08_html", "09_upload", "10_download", "11_timer"
```