### PR TITLE
Added salting to the password

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,8 @@ Imports:
     dplyr,
     rlang,
     sodium,
-    glue
+    glue,
+    digest
 Suggests: 
     DBI,
     RSQLite,

--- a/R/login.R
+++ b/R/login.R
@@ -93,6 +93,7 @@ loginServer <- function(id,
                         data,
                         user_col,
                         pwd_col,
+			salt_col,
                         sodium_hashed = FALSE,
                         log_out = shiny::reactiveVal(),
                         reload_on_logout = FALSE,
@@ -110,6 +111,11 @@ loginServer <- function(id,
   try_class_pc <- try(class(pwd_col), silent = TRUE)
   if (try_class_pc == "character") {
     pwd_col <- rlang::sym(pwd_col)
+  }
+
+  try_class_pc <- try(class(salt_col), silent = TRUE)
+  if (try_class_pc == "character") {
+    salt_col <- rlang::sym(salt_col)
   }
   
   if (cookie_logins && (missing(cookie_getter) | missing(cookie_setter) | missing(sessionid_col))) {
@@ -208,10 +214,13 @@ loginServer <- function(id,
         if (length(row_username)) {
           row_password <- dplyr::filter(data, dplyr::row_number() == row_username)
           row_password <- dplyr::pull(row_password, {{pwd_col}})
+	  salt_password <- dplyr::filter(data, dplyr::row_number() == row_username)
+	  salt_password <- dplyr::pull(salt_password, {{salt_col}})
+
           if (sodium_hashed) {
-            password_match <- sodium::password_verify(row_password, input$password)
+            password_match <- sodium::password_verify(row_password, digest(paste(salt_password,input$password),algo="sha256"))
           } else {
-            password_match <- identical(row_password, input$password)
+            password_match <- identical(row_password, digest(paste(salt_password,input$password),algo="sha256"))
           }
         } else {
           password_match <- FALSE


### PR DESCRIPTION
Added hashing directly to enhance the security, hashed keys are stored in "password" and the salt is added. This will proceed as such:

The salt given to this user + password entered by the user are hashed using sha-256 then compared to the hashed stored in the database for this user. If it is the same, connect the user if not don't connect the user.

This change allows for enhanced security; the passwords are not stored (Let it be on the app, on a database when shiny is launched remotely or if the source code is found.) , only the hashed result and the salt can be found.

Check for more information on salting : https://auth0.com/blog/adding-salt-to-hashing-a-better-way-to-store-passwords/