### PR TITLE
Allow reactive user data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Suggests:
     knitr,
     rmarkdown,
     covr
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.3
 URL: https://github.com/paulc91/shinyauthr
 BugReports: https://github.com/paulc91/shinyauthr/issues
 Config/testthat/edition: 3

--- a/R/login.R
+++ b/R/login.R
@@ -121,8 +121,12 @@ loginServer <- function(id,
     }
   }
   
-  # ensure all text columns are character class
-  data <- dplyr::mutate_if(data, is.factor, as.character)
+  data_reactive <- reactive({
+    # if not already reactive, make data reactive
+    data_temp <- if(is.reactive(data)) data else reactive(data)
+    # ensure all text columns are character class
+    dplyr::mutate_if(data_temp(), is.factor, as.character)
+  })
   
   shiny::moduleServer(
     id,
@@ -191,7 +195,7 @@ loginServer <- function(id,
             
             credentials$user_auth <- TRUE
             credentials$info <- dplyr::bind_cols(
-              dplyr::filter(data, {{user_col}} == .userid),
+              dplyr::filter(data_reactive(), {{user_col}} == .userid),
               dplyr::select(cookie_data, -{{user_col}})
             )
           }
@@ -203,10 +207,10 @@ loginServer <- function(id,
       shiny::observeEvent(input$button, {
         
         # check for match of input username to username column in data
-        row_username <- which(dplyr::pull(data, {{user_col}}) == input$user_name)
+        row_username <- which(dplyr::pull(data_reactive(), {{user_col}}) == input$user_name)
         
         if (length(row_username)) {
-          row_password <- dplyr::filter(data, dplyr::row_number() == row_username)
+          row_password <- dplyr::filter(data_reactive(), dplyr::row_number() == row_username)
           row_password <- dplyr::pull(row_password, {{pwd_col}})
           if (sodium_hashed) {
             password_match <- sodium::password_verify(row_password, input$password)
@@ -221,7 +225,7 @@ loginServer <- function(id,
         if (length(row_username) == 1 && password_match) {
           
           credentials$user_auth <- TRUE
-          credentials$info <- dplyr::filter(data, {{user_col}} == input$user_name)
+          credentials$info <- dplyr::filter(data_reactive(), {{user_col}} == input$user_name)
           
           if (cookie_logins) {
             .sessionid <- randomString()

--- a/R/login.R
+++ b/R/login.R
@@ -68,7 +68,8 @@ loginUI <- function(id,
 #' \href{https://shiny.rstudio.com/articles/modules.html}{Modularizing Shiny app code}.
 #'
 #' @param id 	An ID string that corresponds with the ID used to call the module's UI function
-#' @param data data frame or tibble containing user names, passwords and other user data
+#' @param data data frame or tibble containing user names, passwords and other user data. Can be either
+#'  a static object or a shiny \link[shiny]{reactive} object
 #' @param user_col bare (unquoted) or quoted column name containing user names
 #' @param pwd_col bare (unquoted) or quoted column name containing passwords
 #' @param sodium_hashed have the passwords been hash encrypted using the sodium package? defaults to FALSE
@@ -121,9 +122,9 @@ loginServer <- function(id,
     }
   }
   
-  data_reactive <- reactive({
+  data_reactive <- shiny::reactive({
     # if not already reactive, make data reactive
-    data_temp <- if(is.reactive(data)) data else reactive(data)
+    data_temp <- if (shiny::is.reactive(data)) data else shiny::reactive(data)
     # ensure all text columns are character class
     dplyr::mutate_if(data_temp(), is.factor, as.character)
   })

--- a/man/loginServer.Rd
+++ b/man/loginServer.Rd
@@ -21,7 +21,8 @@ loginServer(
 \arguments{
 \item{id}{An ID string that corresponds with the ID used to call the module's UI function}
 
-\item{data}{data frame or tibble containing user names, passwords and other user data}
+\item{data}{data frame or tibble containing user names, passwords and other user data. Can be either
+a static object or a shiny \link[shiny]{reactive} object}
 
 \item{user_col}{bare (unquoted) or quoted column name containing user names}
 


### PR DESCRIPTION
This will allow updating the allowed users without restarting the app.
Backwards compatible with providing `user_base` as a tibble (meaning `shinyauthr::runExample()` still works).
Example usage using `reactiveFileReader` where usernames and passwords are stored using csv:

`user_base.csv`:
```text
user,password,permissions,name
user1,pass1,admin,User One
user2,pass2,standard,User Two
```

`app.R`:

```r
library(shiny)

user_base <- reactiveFileReader(1000, NULL, 'user_base.csv', read.csv)

ui <- fluidPage(
  # add logout button UI
  div(class = "pull-right", shinyauthr::logoutUI(id = "logout")),
  # add login panel UI function
  shinyauthr::loginUI(id = "login"),
  # setup table output to show user info after login
  tableOutput("user_table"),
  tableOutput("user_table2")
)

server <- function(input, output, session) {
  
  # call login module supplying data frame, 
  # user and password cols and reactive trigger
  credentials <- shinyauthr::loginServer(
    id = "login",
    data = user_base,
    user_col = user,
    pwd_col = password,
    log_out = reactive(logout_init())
  )
  
  # call the logout module with reactive trigger to hide/show
  logout_init <- shinyauthr::logoutServer(
    id = "logout",
    active = reactive(credentials()$user_auth)
  )
  
  output$user_table <- renderTable({
    # use req to only render results when credentials()$user_auth is TRUE
    req(credentials()$user_auth)
    credentials()$info
  })
  # DEBUG
  output$user_table2 <- renderTable({
    user_base()
  })
}

shinyApp(ui = ui, server = server)
```